### PR TITLE
Fix markdown linter errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ syntax. Spor itself is self-bootstrapped from an extremely lean native
 implementation, which is ~1-2 thousand lines of C.
 
 Fngi itself has the following space targets:
+
 - >=32KiB microcontroller/processor: can bootstrap a text-based OS providing
   human-editable source and assembly that can be recompiled on the
   microcontroller (aka self-bootstrapping). The processor does _not_ need to
@@ -28,15 +29,17 @@ Fngi itself has the following space targets:
   be self-bootstrapping.
 
 Read more:
-* [spor.md](./spor.md)
-* [fngi.md](./fngi.md)
-* [harness and zoab](./harness.md)
-* [Unstructured Notes](./notes/)
+
+- [spor.md](./spor.md)
+- [fngi.md](./fngi.md)
+- [harness and zoab](./harness.md)
+- [Unstructured Notes](./notes/)
 
 > Fngi and civboot should be considred an
 > [Obsolete Technology](http://xkcd.com/1891)
 
-# Goals
+## Goals
+
 fngi's goal is to evolve into nothing less than the primary programming language
 and operating system for [Civboot](http://civboot.org). There are many steps
 along the way, some of them complete.
@@ -68,12 +71,12 @@ along the way, some of them complete.
 
 [zoa]: http://github.com/vitiral/zoa
 
-# Helping / Hacking
+## Helping / Hacking
 
 The command to compile and run fngi and all tests is below. This will continue
 to be evolved.
 
-```
+```sh
 ./fngi --compile --test --syslog=LOG_COMPILER --log=LOG_INFO
 ```
 
@@ -107,13 +110,13 @@ Quick code walkthrough:
 When opening a PR to submit code to this repository you must include the
 following disclaimer in your first commit message:
 
-```
+```text
 I <author> assent to license this and all future contributions to this project
 under the dual licenses of the UNLICENSE or MIT license listed in the
 `UNLICENSE` and `README.md` files of this repository.
 ```
 
-# LICENSING
+## LICENSING
 
 This work is part of the Civboot project and therefore primarily exists for
 educational purposes. Attribution to the authors and project is appreciated but
@@ -126,7 +129,7 @@ If for any reason the UNLICENSE is not valid in your jurisdiction or project,
 this work can be singly or dual licensed at your discression with the MIT
 license below.
 
-```
+```text
 Copyright 2021 Garrett Berg
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/fngi.md
+++ b/fngi.md
@@ -9,6 +9,7 @@ syntax". It is defined as a syntax where the compiler only reads a token stream
 and never creates an abstract syntax tree of any kind.
 
 ## Fngi basics
+
 Fngi is a stack based language. Most stack based languages (i.e. FORTH) use
 postfix notation, also called reverse polish notation. However, most "modern"
 (and more readable) languages use prefix notation, also called standard polish
@@ -25,13 +26,14 @@ postfix notation (they don't need `()` or `;`). However, by convention they
 are followed with `;`
 
 Fngi has a few tokens defined for documentation/syntactic surgar:
-* `,` does nothing and is intended as syntactic surgar (documentation) to
+
+- `,` does nothing and is intended as syntactic surgar (documentation) to
   separate arguments in functions.
-* `;` does nothing and is intended to be consumed when no arguments are being
+- `;` does nothing and is intended to be consumed when no arguments are being
   passed to a PRE function, i.e. `ret;`
-* `_` does nothing and is intended to be consumed (and document) when a value is
+- `_` does nothing and is intended to be consumed (and document) when a value is
   from the stack, i.e. `add(_, 2)`
-* `\` is a swiss-army knife comment, described below. It can also be consumed
+- `\` is a swiss-army knife comment, described below. It can also be consumed
   and document values from the stack, i.e. `add(\a, 2)` or `\a + \b`
 
 Unlike C (or most languages) that have an abstract syntax tree, fngi goes about
@@ -46,7 +48,7 @@ For example: `myFn 1`
 
 Gets compiled as (spor assembly, see spor.md):
 
-```
+```spor
 #1$L0     \ compile literal 0x1
 $xsl myFn \ compile a call to myFn
 ```
@@ -57,7 +59,8 @@ So how do we pass more than one argument? It's easy, we use parenthesis!
 So we can do: `myFn2(1, 2 + 3)`
 
 Which is compiled as
-```
+
+```spor
 #1$L0      \ literal 0x1
 #2$L0      \ literal 0x2
 #3$L0      \ literal 0x3. Note + was PRE so this is before %ADD
@@ -66,23 +69,26 @@ $xsl myFn2 \ call to myFn2, which will have a stack of {1 5}
 ```
 
 ### Comments
+
 The ultimate "do nothing" token is the swiss-army knife comment: `\`
 
 Comments have three forms:
-* `\token` comments out a single token.
-* `\ line comment` is a line comment
-* `\(block comment)` is a block comment
+
+- `\token` comments out a single token.
+- `\ line comment` is a line comment
+- `\(block comment)` is a block comment
 
 So you might write one of the below:
-* `myFn(_, 2 + 2)  \ "a" from the stack`
-* `myFn(\a, 2 + 3)`
-* `myFn(\(&a), 2 + 3)`
+
+- `myFn(_, 2 + 2)  \ "a" from the stack`
+- `myFn(\a, 2 + 3)`
+- `myFn(\(&a), 2 + 3)`
 
 ## Example
 
 Below is an example fngi function to calculate fibronacci recursively.
 
-```
+```fngi
 fn fib [n:U4] -> U4 do (
   if(.n <= 1) do ret 1;
   ret(fib(dec .n) + fib(.n - 2));
@@ -108,25 +114,29 @@ Let's explain a few details on how the parser/compiler stays extremely minimal:
   treated as a constant or function (which might be SYN/NOW).
 
 ## Fngi syntax
+
 Fngi has the following rules for token groups.
 
 "Single tokens": these tokens are never grouped together
 
-* `( ... )`: groups an execution.
-* `   $   `: run next token/s NOW (compile time). Can be `$( ... )`
-* `   .   `: enter name compiler `.foo = myFn(3)`
+- `( ... )`: groups an execution.
+- `$`: run next token/s NOW (compile time). Can be `$( ... )`
+- `.`: enter name compiler `.foo = myFn(3)`
 
 Otherwise a token is a group of:
-* alphanumeric characters (including `_`), i.e. `foo_bar123`
-* symbol characters not in the above "single" tokens, i.e. `+-*&` is a single
+
+- alphanumeric characters (including `_`), i.e. `foo_bar123`
+- symbol characters not in the above "single" tokens, i.e. `+-*&` is a single
   token
 
 Functions can be defined for any token that is not purely numeric
-* Numerics: `0x123 (hex)  12345 (decimal)  0b110101 (binary)  0cA 0c\n
+
+- Numerics: `0x123 (hex)  12345 (decimal)  0b110101 (binary)  0cA 0c\n
   (ascii character)`
-* Valid function names:  `+++  0b12 (not binary)  123xx (not decimal)`
+- Valid function names:  `+++  0b12 (not binary)  123xx (not decimal)`
 
 ## Fngi "macros": SYN and NOW
+
 Fngi allows any function to be run "NOW" at compile time. In spor this is
 done using `$token` and it is very similar in fngi.
 
@@ -153,7 +163,8 @@ For example `$(1 + 3)` will put `4` on the stack at compile time. However,
 `1 + 3` will compile both the literals and the `%ADD` instruction into the
 function.
 
-# Similarities to FORTH
+## Similarities to FORTH
+
 Like FORTH, fngi allows you to define functions that are either compiled or
 run NOW (affecting compilation, often called "macros" in other
 languages). Also like FORTH, fngi's functions operate by push/poping from a
@@ -165,6 +176,7 @@ or any other bells or whistles. They practically bootstraps themselves from
 nothing.
 
 Spore diverges from FORTH in the following ways:
+
 - Does not follow FORTH naming standards in any way. Typically closer to
   C naming.
 - Although it is stack-based, all functions (except those with no stack inputs
@@ -177,19 +189,23 @@ Spore diverges from FORTH in the following ways:
   executed and deallocate when returned.
 - Has less dependence on the working stack (data stack in FORTH).
 
-```
+```c
 // C Syntax
 uint32_t fib(uint32_t n) {
     if (n <= 1) return 1;
     return fib(n-1) + fib(n-2);
 }
+```
 
+```forth
 ( FORTH Syntax)
 :FIB ( n -> fibN)
   DUP 1 <= IF DROP 1 EXIT THEN
   DUP -1 FIB        ( n fib(n-1) }
   SWP 2 - FIB + ;
+```
 
+```fngi
 \ Fngi Syntax
 fn fib [n:U4] -> U4 do (
   if(.n <= 1) do ret 1;
@@ -204,17 +220,15 @@ the above is basically no more complicated than FORTH's.
 There are definitely a few areas of complexity in fngi that are not in forth
 though:
 
-* The virtual machine model definitely adds a bit of complexity, and the range
+- The virtual machine model definitely adds a bit of complexity, and the range
   of operations supported by the virtual machine (locals, global offset,
   security, etc) adds some complexity. However, it (in theory) reduces the
   binary size and allows easier portability. Really one just needs to port spor
   and fngi comes along for the ride!
-* Support of the locals stack requres an extra stack, but also reduces the
+- Support of the locals stack requres an extra stack, but also reduces the
   needed size of the working (data) stack.
-* Support of a range of dictionary types, like constant, syn, pre, etc has a
+- Support of a range of dictionary types, like constant, syn, pre, etc has a
   little more complexity. However, FORTH already had to handle NOW functions, so
   the complexity is largely in the forth compiler too.  Add to this that fngi
   provides basic type checking from the beginning (you can't execute a constant
   for instance) makes things well worth it.
-
-

--- a/notes/code_dump.md
+++ b/notes/code_dump.md
@@ -1,12 +1,13 @@
 # Code Dump: where code goes to die
 
-## fetch/store local offset
+## Fetch/Store Local Offset
 
 This was replaced by FTO and SRO
 
 
 In C:
-```
+
+```c
 FTLO: case SzI2 + FTLO:
     l = fetch(mem, LS_SP + popLit(SzI1), SzIA); // &local
     return WS_PUSH(fetch(mem, l + popLit(SzI1), szI)); // fetch offset
@@ -20,7 +21,8 @@ SRLO: case SzI2 + SRLO:
 ```
 
 In spor test:
-```
+
+```spor
 \ Test FTLO
 
 #1234 @SZ4 $GLOBAL gStruct
@@ -47,8 +49,9 @@ $testFTSRLocalOffset
 
 ```
 
-# Dot
-```
+## Dot
+
+```spor
 \ # Dot Compiler (.compiler)
 \ The below is the initial compiler for below cases:
 \   .var               \ variable fetch
@@ -92,8 +95,9 @@ $c_dotRefs @@       #2 @DOT_DEREF ^ADD $tAssertEq
 $c_dotRefs          #0                 $tAssertEq
 ```
 
-# Zoa in spor
-```
+## Zoa in spor
+
+```spor
 \ **********
 \ * [10] Zoa strings and logging zoab
 \ See ./harness.md for design reasoning.
@@ -163,8 +167,9 @@ $FN _printz  $PRE \ {&z}: print zoab bytes to user. (single segment)
   @D_comDone$L0 %DVFT %RET
 ```
 
-# Block Allocator
-```
+## Block Allocator
+
+```spor
 \ **********
 \ * Block Allocator (BA)
 \ The Block Allocator (BA) is used to allocate and free 4KiB blocks. It can
@@ -222,8 +227,7 @@ LFN BA_ptrToI PRE \ {&blk &ba -> bi}
   ret((GET blk - ft4(GET ba + BA_blocksOfs)) >> BA_blockPo2);
 ```
 
-
-```
+```spor
 SFN BA_iGet  PRE ret ft1(_ + ft4(_)) \ {bi &ba -> bi}
 SFN BA_iSet  PRE  \ {value bi &ba}  set ba@bi = value
   _ + ft4(_) \ {value &index}
@@ -304,7 +308,7 @@ SFN SLL_push PRE \ {&a &root}: Push a node onto the SLL
   ret sr4(\a, \root); \ root->a
 ```
 
-```
+```spor
 \ **********
 \ * Arena Allocator (AA)
 \ The arena budy allocator is built on top of the BA. It allows allocations of
@@ -414,7 +418,7 @@ LFN AA_allocPo2 PRE \ {po2 &aa -> &free} allocate memory of size po2
 $c_dictDump
 ```
 
-```
+```spor
 \ **********
 \ ** Test Block Allocator
 $tAssertEq(0xFF, BA_iNull)
@@ -565,7 +569,7 @@ $tAssertEq(GET AA_blk0 + (1<<10), AA_allocExactPo2(10, REF AA_fake))
 $tAssertEq(NULL                 , AA_allocExactPo2(11, REF AA_fake))
 ```
 
-```
+```spor
 \ All roots are now null
 $tAssertEq(NULL, ft4(REF AA_fake + (2<<2)))
 $tAssertEq(NULL, ft4(REF AA_fake + (3<<2)))

--- a/notes/core_structs.md
+++ b/notes/core_structs.md
@@ -1,2 +1,5 @@
 # Core Structs
-There are a few core 
+
+There are a few core structs.
+
+[WIP]

--- a/notes/defer.md
+++ b/notes/defer.md
@@ -2,25 +2,26 @@
 
 fngi will support defer. It will be similar to golang with a few caveats:
 
-  - There is no "defer stack". The first defer simply puts the beginning of the
-    block on the call stack. Following defers mutate this value (and the end of
-    their blocks is a hard-jump to the previous defer block).
-  - Because of the hard-jumping nature, you cannot (should not?) use defers
-    inside of if-statements. This is especially true of the first defer.
-    For continuing defers, if it is skipped it won't run... unless there is a
-    defer _after_ it (since all the defer blocks are hard-wired together).  This
-    makes it extremely touchy when code changes.
-    - Skipping the first defer will cause later defers to mutate the existing
-      callstack: _very_ bad.
-    - However, if there was only one defer or you could guarantee ALL defers
-      were skipped if it was skipped then it could be skipped... at your own
-      risk!
-  - Defers do nothing special when a panic happens. In other words, panics
-    ignore defer just like they ignore the call stack.
-  - The defered token has no special handling of arguments before the deferred
-    code executes... why does golang even do that???
+- There is no "defer stack". The first defer simply puts the beginning of the
+  block on the call stack. Following defers mutate this value (and the end of
+  their blocks is a hard-jump to the previous defer block).
+- Because of the hard-jumping nature, you cannot (should not?) use defers
+  inside of if-statements. This is especially true of the first defer.
+  For continuing defers, if it is skipped it won't run... unless there is a
+  defer _after_ it (since all the defer blocks are hard-wired together).  This
+  makes it extremely touchy when code changes.
+  - Skipping the first defer will cause later defers to mutate the existing
+    callstack: _very_ bad.
+  - However, if there was only one defer or you could guarantee ALL defers
+    were skipped if it was skipped then it could be skipped... at your own
+    risk!
+- Defers do nothing special when a panic happens. In other words, panics
+  ignore defer just like they ignore the call stack.
+- The defered token has no special handling of arguments before the deferred
+  code executes... why does golang even do that???
 
 When the `defer` is called it compiles a `DST` (defer start) instr and empty byte. This:
+
 - pushes ep+2 onto the call stack
 - jmps forward by the byte amount.
 - The empty byte should be updated with the block size by an END or equivalent.
@@ -30,6 +31,7 @@ byte.
 
 When the next `defer` is called it compiles a `DCON` (defer continue) instr and
 empty byte. This:
+
 - **mutates** the call stack (doesn't push) to be ep+2
 - jmps foward by the byte amount (which again is determined by next token).
 
@@ -46,7 +48,7 @@ will ret like a "normal" function.
 Conceptually, defer statements work by putting a defer block of code on a stack.
 The deferred blocks are then executed in FILO (first in last out) order.
 
-```
+```fngi
 fn foo[] do (
   defer println(|printed last|);
   .v = .Foo.new() defer (
@@ -68,15 +70,18 @@ fn foo[] do (
 If a `ret` was run before a defer, then those deferred items won't be run.
 
 Defers are mostly used for:
-  - freeing memory before function return.
-  - closing open resources.
-  - performing logic that must be placed at the end.
+
+- freeing memory before function return.
+- closing open resources.
+- performing logic that must be placed at the end.
 
 ## Type Stack
+
 Defers work with the type-stack system. The rules are:
-  - Defer blocks are assumed to have nothing on the stack when they start and
-    should "ret" nothing.
-  - Otherwise, rets are checked as they normally are.
+
+- Defer blocks are assumed to have nothing on the stack when they start and
+  should "ret" nothing.
+- Otherwise, rets are checked as they normally are.
 
 If all returns are rets the right types, and all defers are returning nothing,
 then the function will return the values it says it will.
@@ -84,4 +89,3 @@ then the function will return the values it says it will.
 > Possible feature: defer blocks that return something could "pop" that type off
 > the _bottom_ of the return type stack. Thus you could use defers for returning
 > values. Would probably want to specify this with, i.e. `defer [U4] ( ... )`
-

--- a/notes/dot.md
+++ b/notes/dot.md
@@ -3,7 +3,7 @@
 The dot compiler is probably the most syntax-heavy component of fngi.
 The initial dot compiler supports all of the below syntaxes:
 
-```
+```fngi
 \   .var            \ variable fetch
 \   .var = <token>  \ variable store
 \   .&var           \ variable reference (also function)

--- a/notes/fngi_syntax.md
+++ b/notes/fngi_syntax.md
@@ -1,6 +1,8 @@
+# fngi syntax
 
-Function syntax
-```
+## Function syntax
+
+```fngi
 fn foo [?a:U4 ?b:U2 c:u4] -> [U4] do (
   // ...
 )

--- a/notes/misc.md
+++ b/notes/misc.md
@@ -1,3 +1,5 @@
+# Misc. notes
+
 ## Endianness
 
 Little/Big endian do NOT refer to which "end" is the "big" (aka most
@@ -17,11 +19,11 @@ number at the head.
 
 These are super critical
 
-- baseball: ba5eba11 
+- baseball: ba5eba11
 - foosball: f005ba11
 - bedablle
 - a caboose: aCab005e
-- deadbeat: DeadBea7 
+- deadbeat: DeadBea7
 - eat beef: 0Ea7Beef
 - defecate: 00Defec8
 - defect: 00Defec7

--- a/notes/os.md
+++ b/notes/os.md
@@ -1,4 +1,5 @@
 # Civboot OS
+
 The purpose of fngi (and spore) is to bootstrap into a Civboot OS. It also wants
 to be a general-purpose programming language outside of Civboot, but that is
 it's primary purpose.
@@ -14,6 +15,7 @@ behind a permissions model/etc. Interestingly, almost everything here makes it
 a better (more secure) general purpose language as well.
 
 The first point is that there needs to be some concept of the following:
+
 - ring: there is only ring0 and ring-other. ring0 can access and write to any
   memory and do anything. ring-other is a number between 1-127 which can only
   write to memory within it's ring.
@@ -23,6 +25,7 @@ The first point is that there needs to be some concept of the following:
 - permissions: a U32 containing permissions bits regarding what the proc can do.
 
 The basic architecture:
+
 - The interpreter keeps a bytearray where each byte represents a 4k block in
   system memory. This is called the memring. Each byte is a ring number where
   the highest bit represents whether the 4k block is globally readable.
@@ -33,6 +36,7 @@ The basic architecture:
 In the final Civboot, the above (or some version that is better which I haven't
 thought of yet) will be powered by the hardware. The advantages to the above
 are:
+
 - Low runtime cost w/out hardware, zero runtime cost with hardware. Register
   memory or a separate small (10-12 bit) bus could be used for the ring array
   to enable zero-cost checking of memory access. Possibly the memory itself
@@ -46,6 +50,7 @@ are:
   processes).
 
 ## Proc Model
+
 The core data type throughout the OS is the 4k block and the Arena allocator.
 Processes communicate by passing bvalues and arenas between eachother,
 where bvalue is the primary "root" value being communicated. Both can be null.
@@ -62,6 +67,7 @@ of entire blocks and arenas, reducing the glue that commonly exists between
 processes serializing and deserializing simple data.
 
 ## Device Registration
+
 Not all device operations need to be implemented by the native backend. Most
 will be "registered" and the native backend will simply execute them. Before
 executing them it will:
@@ -79,6 +85,7 @@ job to do appropriate permissions checking.
 DeviceId=0 is reserved for compiler-internal operations and will be protected
 by a permissions bit. DeviceId=1 will be used for "os" operations and uses
 various permissions bits. The operations include:
+
 - log for writing bvalue logs. Caller must drop bvalue.
 - env for fetching environment values.
 - block for de/allocing from the block allocator
@@ -98,5 +105,5 @@ various permissions bits. The operations include:
 > access things ergonomically.
 
 ## Permissions Bits
-TODO: need to define.
 
+TODO: need to define.

--- a/notes/role.md
+++ b/notes/role.md
@@ -21,7 +21,7 @@ a different way of handling movement.
 > type-checked way without much complexity in fngi, see the botom of this
 > document.
 
-```
+```c
 typedef struct {
   size_t lastSaidIndex;
   Meat favoriteMeat;
@@ -35,7 +35,7 @@ typedef struct {
 
 Let's also say there were a set of methods you wanted to pass around with these:
 
-```
+```c
 typedef struct {
   char* (*talk)(void* animal);               // "talk" function pointer
   char* (*move)(void* animal, int x, int y); // "move to x,y" function pointer
@@ -46,7 +46,7 @@ One way you could make Dog or Goat a virtual type is to essentially mimic
 Rust/C++ "fat pointers" and pass around a pointer to the (global) method
 implementation along with a pointer to the data.
 
-```
+```c
 char* goatTalk(Goat* goat) {
   print(goatWords[goat->lastSaidIndex]);
   goat->lastSaidIndex += 1;
@@ -108,7 +108,7 @@ This allows you to do `.animal.walk(5, 6)`, etc.
 
 For roles, you can simply do:
 
-```
+```fngi
 \ Define animal role
 role Animal [
   fn talk [#Animal];
@@ -143,9 +143,9 @@ supported by the syntax. That really should be rarely necessary, and you could
 (of course) pass the same data twice for the rare cases it is needed.
 
 ## What about that favorite food?
+
 These have all been concrete types, aka non-generic. What about if you wanted to
 have a `fn feed [Food]` method, where `Food` is generic over `Grass` and `Meat`?
 
 Haha, gotcha! There is no way in Hel fngi will support generics.  However,
 `Food` could be an Enum... or even an role type itself!
-

--- a/notes/struct.md
+++ b/notes/struct.md
@@ -2,7 +2,7 @@
 
 STRUCT's are defined with the following syntax:
 
-```
+```fngi
 STRUCT 0x40 Name [ // 64=size of TY_DICT dictionary for this struct.
   field1: U4
   field2: U4
@@ -16,14 +16,13 @@ STRUCT 0x40 Name [ // 64=size of TY_DICT dictionary for this struct.
 - field1-3 are keys in this other dictionary. They are `TY_FIELD`
   and have a pointer to their type and offset, among other things.
 
-
 Before `TY_DICT` can be implemented I must implement both block and buddy-arena
 alloctors.
 
 In the long-term (with the dot compiler) structs can be created using something
 like the following:
 
-```
+```fngi
 .foo = {
   field1 = 4;
   field2 = 5;
@@ -36,7 +35,7 @@ implement `VAR`, an untyped pre-cursor to the `.` compiler. This automatically
 handles recursive lookups. It does NOT handle assigning structs to a struct
 constructor, type checking, or many other things.
 
-```
+```fngi
 // foo (concrete local struct)
 VAR foo.field;
 VAR foo.field = 7;

--- a/notes/why-not-wasm.md
+++ b/notes/why-not-wasm.md
@@ -1,2 +1,3 @@
-Moved to https://github.com/civboot/civboot/blob/main/thoughts/why-not-wasm.md
+# Why not WASM?
 
+Moved to <https://github.com/civboot/civboot/blob/main/thoughts/why-not-wasm.md>

--- a/spor.md
+++ b/spor.md
@@ -5,6 +5,7 @@
 
 Spor is a stack-based assembler which borrows design princples from FORTH. It
 is designed for the following principles:
+
 - Self-bootstrapping in as little native code as possible, while still meeting
   the other goals.
 - Support the self-bootstrapping of fngi with shared utilities like a scanner,
@@ -25,7 +26,7 @@ values and a register to store the current instr "sz bits" of `SZ1`, `SZ2` or
 
 The syntax looks like
 
-```
+```spor
 \ (sfn means "small function" aka no locals)
 $SFN add1   \ [U4] -> [U4]: add one
   #1$L0       \ compile literal of 0x1
@@ -40,6 +41,7 @@ The assembler syntax is obsenely simple and fngi builds on top of it. It
 supports the following tokens.
 
 Pushing and setting stack values:
+
 - `\` starts a line comment which ends at the newline.
 - `.N` sets the sz bits (size) to N bytes, i.e. `.4` set's the global
   instruction size to 4 bytes (`SZ4`).
@@ -47,13 +49,14 @@ Pushing and setting stack values:
   `#1_2345` pushes 0x12345.
 - `=<token>` set's the dictionary entry for `<token>` to the value on the stack.
   i.e. `#42 =foo` would set `foo` to 0x42.
-- `@<token>` get's the dictionary entry for <token>`. I.e. `@foo` would put 0x42
+- `@<token>` get's the dictionary entry for `<token>`. I.e. `@foo` would put 0x42
   on the stack (assuming it had been set like above).
 - `,` pops a value from stack and writes it to heap and increments heap. The
   size is controlled by `.` (note: this is rarely used, pretty much just for
   bootstrapping h1, h2, etc).
 
 Compiling and executing instructions:
+
 - `%` compile the next token's dictionary value as an instruction. Does not
   clear sz bits (set by `.`).
 - `^` run the next token's dictionary value as an instruction. This is useful
@@ -64,7 +67,8 @@ Compiling and executing instructions:
   heap at the location in asm.
 
 From the above we can now break down this code:
-```
+
+```spor
 $SFN add1
   #1$L0
   %ADD %RET
@@ -81,4 +85,3 @@ execute as a literal. "Small" means the function has no locals stack.
 
 Read the full documentation in [spor.sp](./spor.sp). There is vim syntax
 highlighting in `etc/spor.vim`
-


### PR DESCRIPTION
I have a markdowns linter, and here I have fixed up the code so that it passes standard markdown formating.